### PR TITLE
[🔧]Gemfile.lock {213}:  aarch64-linux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,6 +128,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.5-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.6)
@@ -208,6 +210,7 @@ GEM
     zeitwerk (2.6.14)
 
 PLATFORMS
+  aarch64-linux
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
m1チップ搭載のMacに対応.