### PR TITLE
[✨fix]command コンテナを立ち上げたときのコマンドを改善

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem "pg", "~> 1.1"
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", ">= 5.0"
 
+gem "pad_character"
+
 # Bundle and transpile JavaScript [https://github.com/rails/jsbundling-rails]
 gem "jsbundling-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.5-x86_64-linux)
       racc (~> 1.4)
+    pad_character (0.1.0)
     parallel (1.24.0)
     parser (3.3.2.0)
       ast (~> 2.4.1)
@@ -267,6 +268,7 @@ DEPENDENCIES
   friendly_id (~> 5.5.0)
   jbuilder
   jsbundling-rails
+  pad_character
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.3)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
 css: yarn build:css --watch

--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,13 @@ services:
       - 5432:5432
   web:
     build: .
-    command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
+    command: >
+              bash -c "rm -f tmp/pids/server.pid && 
+              bundle install &&
+              yarn install &&
+              yarn build &&
+              yarn build:css &&
+              bundle exec rails s -p 3000 -b '0.0.0.0'"
     tty: true
     stdin_open: true
     volumes:


### PR DESCRIPTION
docker-compose.yml のコマンドを以下のように変更

```diff
    command: >
              bash -c "rm -f tmp/pids/server.pid && 
+              bundle install &&
+              yarn install &&
+              yarn build &&
+              yarn build:css &&
              bundle exec rails s -p 3000 -b '0.0.0.0'"
```
( ローカルとリモートでGemfileに差異があるときでも compos upだけの実行で良いようにした。 )