### PR TITLE
[✨fix]usersテーブルのカラムを修正

### DIFF
--- a/db/migrate/20240619131604_rename_events_id_to_event_id_in_users.rb
+++ b/db/migrate/20240619131604_rename_events_id_to_event_id_in_users.rb
@@ -1,0 +1,5 @@
+class RenameEventsIdToEventIdInUsers < ActiveRecord::Migration[7.1]
+  def change
+    rename_column :users, :events_id, :event_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_28_083120) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_19_131604) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -51,16 +51,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_28_083120) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.bigint "events_id", null: false
+    t.bigint "event_id", null: false
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["events_id"], name: "index_users_on_events_id"
+    t.index ["event_id"], name: "index_users_on_event_id"
   end
 
   add_foreign_key "comments", "users"
   add_foreign_key "schedules", "events"
   add_foreign_key "user_schedules", "schedules"
   add_foreign_key "user_schedules", "users"
-  add_foreign_key "users", "events", column: "events_id"
+  add_foreign_key "users", "events"
 end


### PR DESCRIPTION
usersテーブルのevents_idをevent_idに変更
```diff
create_table "users", force: :cascade do |t|
+  t.bigint "event_id", null: false
-  t.bigint "events_id", null: false
   t.string "name", null: false
   t.datetime "created_at", null: false
   t.datetime "updated_at", null: false
   t.index ["events_id"], name: "index_users_on_events_id"
 end
```