### PR TITLE
issue_#11 イベントURL・パスワードの共有画面の作成

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -25,10 +25,15 @@ class EventsController < ApplicationController
       params[:event][:dates].split(',').map { |date| date.strip }.reject(&:empty?).uniq.each do |date|
         @event.schedules.create(date: Date.strptime(date, '%Y-%m-%d'))
       end
-      redirect_to @event, notice: "Event was successfully created."
+      # redirect_to @event, notice: "Event was successfully created."
+      redirect_to url_share_event_path(@event.url_slug), notice: "Event was successfully created."
     else
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def url_share
+    @event = Event.find_by(url_slug: params[:url_slug])
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -25,7 +25,6 @@ class EventsController < ApplicationController
       params[:event][:dates].split(',').map { |date| date.strip }.reject(&:empty?).uniq.each do |date|
         @event.schedules.create(date: Date.strptime(date, '%Y-%m-%d'))
       end
-      # redirect_to @event, notice: "Event was successfully created."
       redirect_to url_share_event_path(@event.url_slug), notice: "Event was successfully created."
     else
       render :new, status: :unprocessable_entity

--- a/app/javascript/copy.js
+++ b/app/javascript/copy.js
@@ -1,0 +1,41 @@
+document.addEventListener("turbo:load", () => {
+  const passwordCopyBtn = document.getElementById("password_copy_btn");
+  const password = document.getElementById("password").innerText;
+  const passwordDane = document.getElementById("password_dane");
+
+  const urlCopyBtn = document.getElementById("url_copy_btn");
+  const url = document.getElementById("url").innerText;
+  const urlDone = document.getElementById("url_done");
+
+  passwordCopyBtn.addEventListener("click", () => {
+    navigator.clipboard.writeText(password).then(
+      () => {
+        // コピー成功時の処理;
+        passwordDane.style.display = "block";
+        setTimeout(() => {
+          passwordDane.style.display = "none";
+        }, 3000);
+      },
+      () => {
+        // コピー失敗の処理
+        alert("コピーに失敗しました");
+      }
+    );
+  });
+
+  urlCopyBtn.addEventListener("click", () => {
+    navigator.clipboard.writeText(url).then(
+      () => {
+        // コピー成功時の処理;
+        urlDone.style.display = "block";
+        setTimeout(() => {
+          urlDone.style.display = "none";
+        }, 3000);
+      },
+      () => {
+        // コピー失敗の処理
+        alert("コピーに失敗しました");
+      }
+    );
+  });
+});

--- a/app/views/events/url_share.html.erb
+++ b/app/views/events/url_share.html.erb
@@ -1,0 +1,26 @@
+<div class="flex items-center justify-center h-screen" data-controller="copy">
+  <div class="card bg-base-100 shadow-xl min-w-fit max-w-md">
+    <div class="card-body">
+      <h2 class="card-title">イベント名: <%= @event.title %></h2>
+      <p><%= @event.description %></p>
+      <div class="flex items-center">
+        <p>イベントページURL: </p>
+        <h3 class="mx-3 flex-grow-0 flex-shrink-0"> 
+          <%= link_to "http://localhost:3001/events/#{@event.url_slug}", event_path(@event.url_slug) ,target: "_blank", class: "text-blue-500 underline", id: "url" %>
+
+          <%# <%= link_to "https://sharesuke.onrender.com/events/#{@event.url_slug}", event_path(@event.url_slug) ,target: "_blank", class: "text-blue-500 underline", id: "url" %>
+          <%# 本番用URL 公開前に変更する %>
+        </h3>
+        <button class="btn btn-xs btn-success flex-grow-0 flex-shrink-0" id="url_copy_btn">コピー</button>
+        <div class="tooltip tooltip-open tooltip-right hidden mb-2" id="url_done" data-tip="コピーしました！"></div>
+      </div>
+      <div class="flex items-center">
+        <h1>パスワード: </h1>
+        <p id="password" class="flex-grow-0 flex-shrink-0 font-bold px-2"><%= @event.password %></p>
+        <button class="btn btn-xs btn-success flex-grow-0 flex-shrink-0" id="password_copy_btn">コピー</button>
+        <div class="tooltip tooltip-open tooltip-right hidden mb-2" id="password_dane" data-tip="コピーしました！"></div>
+      </div>
+    </div>
+  </div>
+</div>
+<%= javascript_include_tag "copy" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,10 @@
 Rails.application.routes.draw do
   root 'top#index'
   resources :events, only: %i[index new create show], param: :url_slug do
+    member do
+      get :url_share
+    end
     resources :users, only: %i[create edit update destroy]
   end
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end


### PR DESCRIPTION
お疲れ様です！！
 issue_#11のURL、パスワード招待情報実装しました。
ご確認のほどよろしくお願いします！
*** 

- [x]  **イベント作成時のリダイレクト先を変更**
作成後にURL, パスワードを表示し共有できる画面に飛ばしてます。
**※ パスワードのハッシュ化の後はURLだけの表示になるかと思います。**

[![Image from Gyazo](https://i.gyazo.com/150968202bc823298f38614f11280402.gif)](https://gyazo.com/150968202bc823298f38614f11280402)

```diff
-      redirect_to @event, notice: "Event was successfully created."
+      redirect_to url_share_event_path(@event.url_slug), notice: "Event was successfully created."
    else
      render :new, status: :unprocessable_entity
    end
  end

+  def url_share
+   @event = Event.find_by(url_slug: params[:url_slug])
+  end
```
*** 

- [x]  **copy.jsの作成**
- ボタンクリックでクリップボードにコピーするためcopy.jsを作成しJavaScriptで実装してます
**※ React導入する段階でJSをReactに変更するかは別途相談できればと思います**

[![Image from Gyazo](https://i.gyazo.com/e51de97c0da04a22de9f8c4211c0beb5.gif)](https://gyazo.com/e51de97c0da04a22de9f8c4211c0beb5)

*** 

- [x] ルーティング追加しました。memberで別名にしてルーティングを作成しています。
また使用していないコード・コメントアウトを削除しました。

```diff
Rails.application.routes.draw do
  root 'top#index'
  resources :events, only: %i[index new create show], param: :url_slug do
+    member do
+     get :url_share
+    end
    resources :users, only: %i[create edit update destroy]
  end
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
-  get "up" => "rails/health#show", as: :rails_health_check
-
-  # Defines the root path route ("/")
-  # root "posts#index"
end
```


